### PR TITLE
Copilot運用ルールとADRドキュメントを追加

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,13 @@
+## 全体
+- 返答、PR，イシューは日本語を使ってください
+- コーディング時、mainブランチの直接編集は避けること
+  - git worktreeで作業用ブランチを`../worktrees/[リポジトリ名]`に作成し作業すること
+  - 作業は原則pushやPR作成まで終わらせてください。
+  - 作業開始前、push前にorigin/mainの変更をpullしてください。
+- uvを使えるところ（pythonパッケージの追加、削除、実行など）はuvを使ってください。
+- GitHub CLI（gh）を使用してください。
+
+## ADR
+
+このテンプレートの重要な設計判断は `docs/adr/` に ADR として保存します。
+- 運用ルール: [`docs/adr/README.md`](docs/adr/README.md)

--- a/docs/adr/00001-replace-pyright-with-ty.md
+++ b/docs/adr/00001-replace-pyright-with-ty.md
@@ -1,0 +1,38 @@
+# ADR 00001: Replace pyright with ty
+
+- Status: accepted
+- Date: 2026-03-21
+- Supersedes: none
+- Superseded by: none
+
+## Context
+
+このテンプレートは AI アシスタント、とくに Copilot CLI との協働を前提にしています。
+
+型チェック系の実行経路としては、`pyproject.toml` の `check` タスク、`.pre-commit-config.yaml` のローカル hook、CI の `uv run pre-commit run --all-files` が使われています。
+
+`pyright` を使い続ける案もありましたが、このテンプレートでは AI エージェントがローカルで何度もチェックを回す前提があるため、実行時間の短さをより重視しました。主な判断理由は、型チェックをより高速に回せる構成へ寄せることです。
+
+2026-03-21 の `pyright` から `ty` への移行では、実際に次のような段階的な調整が発生しました。
+
+- `a7c5bb8`: `pyproject.toml`、`taskipy`、pre-commit hook を `pyright` から `ty` に置き換えた
+- `e1bb0b9`: lockfile にまだ `pyright` が残っていたため、CI で一時的に `ty` を追加インストールする対応を入れた
+- `ba0114d`: 利用可能な版に合わせて `ty==0.0.24` に固定し、CI の依存解決を安定させた
+- `45c08f2`: 実行コマンドを `uv run ty check src` にそろえ、`pass_filenames: false` を加え、暫定 CI 対応を外した
+
+## Decision
+
+このテンプレートでは、型チェック系の標準ツールを `pyright` ではなく `ty` とします。
+
+主な理由は速度です。AI エージェントと人が反復的に型チェックを実行するテンプレートでは、1 回ごとの差が小さくても累積の待ち時間が効いてきます。そのため、このテンプレートでは型チェックの実行速度を優先し、`ty` を標準に採用します。
+
+採用する実行経路は次のとおりです。
+
+- 依存関係は `pyproject.toml` の `dev` グループで `ty==0.0.24` を利用する
+- ローカルの標準コマンドは `uv run ty check src` とする
+- pre-commit hook も `uv run ty check src` を使い、`pass_filenames: false` を設定して明示的に `src` を対象にする
+- CI は追加の暫定インストールを行わず、`uv sync --all-extras` と pre-commit 実行だけで再現できる状態を維持する
+- 今後この判断を見直す場合は、新しい ADR を追加し、この ADR を supersede する
+
+## Consequences
+型チェックをより短い待ち時間で回しやすくなるため、開発者とエージェントの双方が反復を進めやすくなります。

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,69 @@
+# ADR
+
+このディレクトリでは、テンプレートの重要な設計判断を Architecture Decision Record (ADR) として管理します。
+
+説明文を README や instructions に散在させるのではなく、判断の背景・結論・見直し履歴をエージェントと人の両方が追える形で残すことを目的とします。
+
+## 命名規則
+
+- ファイル名は `NNNNN-short-kebab-case.md` 形式にします
+- `NNNNN` は 5 桁の連番です
+- `short-kebab-case` は判断内容を短く表す英語の kebab-case にします
+- 採番は時系列順に増やし、欠番は再利用しません
+
+例:
+
+- `00001-replace-pyright-with-ty.md`
+- `00002-store-agent-policy-as-adr.md`
+
+## ステータス
+
+各 ADR の先頭には少なくとも次のメタデータを置きます。
+
+```md
+# ADR 00001: Title
+
+- Status: accepted
+- Date: 2026-03-21
+- Supersedes: none
+- Superseded by: none
+```
+
+利用するステータスは次の 3 つに限定します。
+
+- `proposed`: 提案中で、まだ標準方針としては採用していない
+- `accepted`: 現在有効な方針
+- `superseded`: 後続の ADR に置き換えられ、現行方針ではない
+
+## superseded の扱い
+
+- 既存 ADR を置き換えるときは、新しい ADR を追加し、古い ADR は削除しません
+- 置き換えられた ADR は `Status: superseded` に更新します
+- 古い ADR の `Superseded by` には後続 ADR の番号とファイル名を記載します
+- 新しい ADR の `Supersedes` には置き換え元 ADR の番号とファイル名を記載します
+- 置き換え関係がない場合は `none` を明記します
+
+## テンプレート
+
+新しい ADR は次のテンプレートから始めます。
+
+```md
+# ADR NNNNN: Title
+
+- Status: proposed
+- Date: YYYY-MM-DD
+- Supersedes: none
+- Superseded by: none
+
+## Context
+
+この判断が必要になった背景を書く。
+
+## Decision
+
+採用する判断を簡潔に書く。
+
+## Consequences
+
+得られる利点、受け入れるトレードオフ、次に必要な作業を書く。
+```


### PR DESCRIPTION
## 概要
- Copilot CLI 向けの運用ルールを `.github/copilot-instructions.md` に追加
- 重要な設計判断を ADR として管理するための運用 README を追加
- `pyright` から `ty` へ移行した判断を ADR 00001 として記録
